### PR TITLE
Rename Angular Camp to JavaScript Camp

### DIFF
--- a/conferences/2018/javascript.json
+++ b/conferences/2018/javascript.json
@@ -1017,13 +1017,13 @@
     "twitter": "@ReactFest"
   },
   {
-    "name": "AngularCamp",
-    "url": "https://angularcamp.org",
+    "name": "JavaScript Camp",
+    "url": "https://jscamp.tech",
     "startDate": "2018-07-18",
     "endDate": "2018-07-20",
     "city": "Barcelona",
     "country": "Spain",
-    "twitter": "@AngularCamp"
+    "twitter": "@jscamptech"
   },
   {
     "name": "React Native EU",


### PR DESCRIPTION
The [Angular Camp website](https://angularcamp.org) now redirects to JSCamp.
Looks like the conference name was renamed to be more generic.