### PR TITLE
Remove VueJS Roadtrip Berlin

### DIFF
--- a/conferences/2018/javascript.json
+++ b/conferences/2018/javascript.json
@@ -1222,15 +1222,6 @@
     "twitter": "@vuejsroadtrip"
   },
   {
-    "name": "Vuejs Roadtrip – Berlin",
-    "url": "https://www.vuejsroadtrip.com",
-    "startDate": "2018-09-14",
-    "endDate": "2018-09-14",
-    "city": "Berlin",
-    "country": "Germany",
-    "twitter": "@vuejsroadtrip"
-  },
-  {
     "name": "Web Summit",
     "url": "https://websummit.com",
     "startDate": "2018-11-05",


### PR DESCRIPTION
It's no longer listed on [their website](https://www.vuejsroadtrip.com/)